### PR TITLE
Update RegEx to support whitespace infront of /run commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update RegEx to support optional whitespace infront of `/run` commands
+
 ## [0.4.0] - 2024-03-11
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	// /run test-cluster-upgrade PRIVATE_NETWORK=false PREVIOUS_VERSION=1.2.6
 	// /run hold wait-for-tests
 	// /run help NAMESPACE=foo-bar test-cluster-create
-	triggerFormat = regexp.MustCompile(`(?mi)^\/run (?P<pipeline>\S+)(?: (?P<args>(?:[A-Z_]+=\S+ ?)*)| (?P<pos>(?:[A-Za-z0-9\-_]+ ?)*))*(?:\r|\n|$)`)
+	triggerFormat = regexp.MustCompile(`(?mi)^\s*\/run (?P<pipeline>\S+)(?: (?P<args>(?:[A-Z_]+=\S+ ?)*)| (?P<pos>(?:[A-Za-z0-9\-_]+ ?)*))*(?:\r|\n|$)`)
 
 	tektonClient *tknclient.Clientset
 	kubeClient   kubernetes.Interface


### PR DESCRIPTION
### What does this PR do?

Allows `/run` commands to have optional whitespace in front of them (and nothing else)

Towards: https://github.com/giantswarm/giantswarm/issues/30434