### PR TITLE
Handle draft PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Handle draft PRs and if triggered from opening add a comment stating that the trigger was ignored
+
 ## [0.6.0] - 2024-07-18
 
 ## [0.5.0] - 2024-04-05

--- a/main.go
+++ b/main.go
@@ -160,6 +160,22 @@ func main() {
 		}
 		env["GIT_REVISION"] = *pr.Head.SHA
 
+		// If PR is draft and triggered from the PR body don't run trigger and instead
+		// inform the user to add a comment
+		if *pr.Draft && env["COMMENT_ID"] == "" {
+			fmt.Println("PR is draft and was triggered from the opening comment, not triggering")
+
+			// TODO: Comment
+			_, _, err = ghClient.Issues.CreateComment(ctx, env["REPO_ORG"], env["REPO_NAME"], prNumber, &github.IssueComment{
+				Body: github.String("> [!NOTE]\n> As this is a draft PR no triggers from the PR body will be handled.\n> \n> If you'd like to trigger them while draft please add them as a PR comment."),
+			})
+			if err != nil {
+				fmt.Println("Failed to add PR comment", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+
 		// Get changed files
 		// TODO: Currently doesn't handle paging so limited to first 100 files but I'd like to refactor more before we introducing paging support
 		files, _, err := ghClient.PullRequests.ListFiles(ctx, env["REPO_ORG"], env["REPO_NAME"], prNumber, &github.ListOptions{PerPage: 100})


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31325

Check if PR is in a draft state and if the run was triggered from an open event (and not a comment) inform the user that we are ignoring any found slash commands.