### PR TITLE
Handle '[bot]' in login name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-
 ## [Unreleased]
+
+### Fixed
+
+- Correctly handle user logins with `[bot]` in their name
 
 ## [0.8.0] - 2024-08-30
 

--- a/main.go
+++ b/main.go
@@ -232,6 +232,10 @@ func main() {
 		}
 		fmt.Printf("Setting workspace storage class to: %s\n", workspaceStorageClass)
 
+		userLogin := env["USER_LOGIN"]
+		// Remove the `[bot]` suffix from the username as the `[]` aren't valid label chars
+		userLogin = strings.TrimSuffix(userLogin, "[bot]")
+
 		pipelineRun := &tkn.PipelineRun{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: fmt.Sprintf("pr-%s-%s-%s", env["REPO_NAME"], env["NUMBER"], trigger.PipelineName),
@@ -240,7 +244,7 @@ func main() {
 					"cicd.giantswarm.io/repo":         env["REPO_NAME"],
 					"cicd.giantswarm.io/pr":           env["NUMBER"],
 					"cicd.giantswarm.io/revision":     env["GIT_REVISION"],
-					"cicd.giantswarm.io/triggered-by": env["USER_LOGIN"],
+					"cicd.giantswarm.io/triggered-by": userLogin,
 				},
 				Annotations: map[string]string{
 					"cicd.giantswarm.io/url": env["URL"],


### PR DESCRIPTION
### What does this PR do?

Fixes: https://github.com/giantswarm/giantswarm/issues/31593

Strips the `[bot]` from the login name when adding it as a label as the `[]` chars aren't valid in a label