### PR TITLE
Main: Implement pagination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Go: Upgrade to v1.23.2.
+- Main: Implement pagination.
 
 ## [0.9.0] - 2024-09-16
 


### PR DESCRIPTION
I triggered a `help` pipeline run here: https://github.com/giantswarm/tinkerers-ci-test-1/pull/29#issuecomment-2460631717

This is the pipeline run in Tekton: https://tekton.ci-dev.giantswarm.io/#/namespaces/tekton-pipelines/pipelineruns/pr-tinkerers-ci-test-1-29-help6fs6c?pipelineTask=get-pipelines&step=list-pipelines&view=logs

Unfortunately you cannot see the passed environment variables in the UI, so I needed to get them directly from the cluster:

```
% kubectl get pipelineruns.tekton.dev --namespace tekton-pipelines pr-tinkerers-ci-test-1-29-help6fs6c --output yaml
[...]
  - name: PR_FILES
    value: test/1.txt,test/10.txt,test/100.txt,test/101.txt,test/102.txt,test/103.txt,test/104.txt,test/105.txt,test/106.txt,test/107.txt,test/108.txt,test/109.txt,test/11.txt,test/110.txt,test/111.txt,test/112.txt,test/113.txt,test/114.txt,test/115.txt,test/116.txt,test/117.txt,test/118.txt,test/119.txt,test/12.txt,test/120.txt,test/121.txt,test/122.txt,test/123.txt,test/124.txt,test/125.txt,test/126.txt,test/127.txt,test/128.txt,test/129.txt,test/13.txt,test/130.txt,test/131.txt,test/132.txt,test/133.txt,test/134.txt,test/135.txt,test/136.txt,test/137.txt,test/138.txt,test/139.txt,test/14.txt,test/140.txt,test/141.txt,test/142.txt,test/143.txt,test/144.txt,test/145.txt,test/146.txt,test/147.txt,test/148.txt,test/149.txt,test/15.txt,test/150.txt,test/151.txt,test/152.txt,test/153.txt,test/154.txt,test/155.txt,test/156.txt,test/157.txt,test/158.txt,test/159.txt,test/16.txt,test/160.txt,test/161.txt,test/162.txt,test/163.txt,test/164.txt,test/165.txt,test/166.txt,test/167.txt,test/168.txt,test/169.txt,test/17.txt,test/170.txt,test/171.txt,test/172.txt,test/173.txt,test/174.txt,test/175.txt,test/176.txt,test/177.txt,test/178.txt,test/179.txt,test/18.txt,test/180.txt,test/181.txt,test/182.txt,test/183.txt,test/184.txt,test/185.txt,test/186.txt,test/187.txt,test/188.txt,test/189.txt,test/19.txt,test/190.txt,test/191.txt,test/192.txt,test/193.txt,test/194.txt,test/195.txt,test/196.txt,test/197.txt,test/198.txt,test/199.txt,test/2.txt,test/20.txt,test/200.txt,test/21.txt,test/22.txt,test/23.txt,test/24.txt,test/25.txt,test/26.txt,test/27.txt,test/28.txt,test/29.txt,test/3.txt,test/30.txt,test/31.txt,test/32.txt,test/33.txt,test/34.txt,test/35.txt,test/36.txt,test/37.txt,test/38.txt,test/39.txt,test/4.txt,test/40.txt,test/41.txt,test/42.txt,test/43.txt,test/44.txt,test/45.txt,test/46.txt,test/47.txt,test/48.txt,test/49.txt,test/5.txt,test/50.txt,test/51.txt,test/52.txt,test/53.txt,test/54.txt,test/55.txt,test/56.txt,test/57.txt,test/58.txt,test/59.txt,test/6.txt,test/60.txt,test/61.txt,test/62.txt,test/63.txt,test/64.txt,test/65.txt,test/66.txt,test/67.txt,test/68.txt,test/69.txt,test/7.txt,test/70.txt,test/71.txt,test/72.txt,test/73.txt,test/74.txt,test/75.txt,test/76.txt,test/77.txt,test/78.txt,test/79.txt,test/8.txt,test/80.txt,test/81.txt,test/82.txt,test/83.txt,test/84.txt,test/85.txt,test/86.txt,test/87.txt,test/88.txt,test/89.txt,test/9.txt,test/90.txt,test/91.txt,test/92.txt,test/93.txt,test/94.txt,test/95.txt,test/96.txt,test/97.txt,test/98.txt,test/99.txt,README.md
  - name: PR_FILES_ADDED
    value: test/1.txt,test/10.txt,test/100.txt,test/101.txt,test/102.txt,test/103.txt,test/104.txt,test/105.txt,test/106.txt,test/107.txt,test/108.txt,test/109.txt,test/11.txt,test/110.txt,test/111.txt,test/112.txt,test/113.txt,test/114.txt,test/115.txt,test/116.txt,test/117.txt,test/118.txt,test/119.txt,test/12.txt,test/120.txt,test/121.txt,test/122.txt,test/123.txt,test/124.txt,test/125.txt,test/126.txt,test/127.txt,test/128.txt,test/129.txt,test/13.txt,test/130.txt,test/131.txt,test/132.txt,test/133.txt,test/134.txt,test/135.txt,test/136.txt,test/137.txt,test/138.txt,test/139.txt,test/14.txt,test/140.txt,test/141.txt,test/142.txt,test/143.txt,test/144.txt,test/145.txt,test/146.txt,test/147.txt,test/148.txt,test/149.txt,test/15.txt,test/150.txt,test/151.txt,test/152.txt,test/153.txt,test/154.txt,test/155.txt,test/156.txt,test/157.txt,test/158.txt,test/159.txt,test/16.txt,test/160.txt,test/161.txt,test/162.txt,test/163.txt,test/164.txt,test/165.txt,test/166.txt,test/167.txt,test/168.txt,test/169.txt,test/17.txt,test/170.txt,test/171.txt,test/172.txt,test/173.txt,test/174.txt,test/175.txt,test/176.txt,test/177.txt,test/178.txt,test/179.txt,test/18.txt,test/180.txt,test/181.txt,test/182.txt,test/183.txt,test/184.txt,test/185.txt,test/186.txt,test/187.txt,test/188.txt,test/189.txt,test/19.txt,test/190.txt,test/191.txt,test/192.txt,test/193.txt,test/194.txt,test/195.txt,test/196.txt,test/197.txt,test/198.txt,test/199.txt,test/2.txt,test/20.txt,test/200.txt,test/21.txt,test/22.txt,test/23.txt,test/24.txt,test/25.txt,test/26.txt,test/27.txt,test/28.txt,test/29.txt,test/3.txt,test/30.txt,test/31.txt,test/32.txt,test/33.txt,test/34.txt,test/35.txt,test/36.txt,test/37.txt,test/38.txt,test/39.txt,test/4.txt,test/40.txt,test/41.txt,test/42.txt,test/43.txt,test/44.txt,test/45.txt,test/46.txt,test/47.txt,test/48.txt,test/49.txt,test/5.txt,test/50.txt,test/51.txt,test/52.txt,test/53.txt,test/54.txt,test/55.txt,test/56.txt,test/57.txt,test/58.txt,test/59.txt,test/6.txt,test/60.txt,test/61.txt,test/62.txt,test/63.txt,test/64.txt,test/65.txt,test/66.txt,test/67.txt,test/68.txt,test/69.txt,test/7.txt,test/70.txt,test/71.txt,test/72.txt,test/73.txt,test/74.txt,test/75.txt,test/76.txt,test/77.txt,test/78.txt,test/79.txt,test/8.txt,test/80.txt,test/81.txt,test/82.txt,test/83.txt,test/84.txt,test/85.txt,test/86.txt,test/87.txt,test/88.txt,test/89.txt,test/9.txt,test/90.txt,test/91.txt,test/92.txt,test/93.txt,test/94.txt,test/95.txt,test/96.txt,test/97.txt,test/98.txt,test/99.txt
[...]
```

As you can see all the files, or at least more than 100, are included now.